### PR TITLE
Use documentFragments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,9 @@ function createFromSelector(selector) {
 }
 
 function append(element, children) {
-  children.forEach(child => element.appendChild(child))
+  const fragment = document.createDocumentFragment()
+  children.forEach(child => fragment.appendChild(child))
+  element.appendChild(fragment)
 }
 
 function extend(element, { className = [], children =[], text, ...attributes }) {


### PR DESCRIPTION
Replace append function to use document fragments, in order to improve performance for large amount of children

```js
function append(element, children) {
  const fragment = document.createDocumentFragment()
  children.forEach(child => fragment.appendChild(child))
  element.appendChild(fragment)
}
```